### PR TITLE
file table: Add version information for Windows file when applicable

### DIFF
--- a/osquery/filesystem/fileops.h
+++ b/osquery/filesystem/fileops.h
@@ -90,6 +90,7 @@ typedef struct win_stat {
   std::string type;
   std::string attributes;
   std::string volume_serial;
+  std::string product_version;
 
 } WINDOWS_STAT;
 

--- a/osquery/filesystem/windows/fileops.cpp
+++ b/osquery/filesystem/windows/fileops.cpp
@@ -1820,6 +1820,8 @@ Status platformStat(const fs::path& path, WINDOWS_STAT* wfile_stat) {
   (!ret) ? wfile_stat->ctime = -1
          : wfile_stat->ctime = longIntToUnixtime(basic_info.ChangeTime);
 
+  windowsGetFileVersion(path.string(), wfile_stat->product_version);
+
   CloseHandle(file_handle);
 
   return Status();

--- a/osquery/tables/utility/file.cpp
+++ b/osquery/tables/utility/file.cpp
@@ -124,6 +124,7 @@ void genFileInfo(const fs::path& path,
   r["attributes"] = TEXT(file_stat.attributes);
   r["file_id"] = TEXT(file_stat.file_id);
   r["volume_serial"] = TEXT(file_stat.volume_serial);
+  r["product_version"] = TEXT(file_stat.product_version);
 
 #endif
 

--- a/specs/utility/file.table
+++ b/specs/utility/file.table
@@ -23,6 +23,7 @@ extended_schema(WINDOWS, [
     Column("attributes", TEXT, "File attrib string. See: https://ss64.com/nt/attrib.html"),
     Column("volume_serial", TEXT, "Volume serial number"),
     Column("file_id", TEXT, "file ID"),
+    Column("product_version", TEXT, "File product version"),
 ])
 attributes(utility=True)
 implementation("utility/file@genFile")

--- a/tests/integration/tables/file.cpp
+++ b/tests/integration/tables/file.cpp
@@ -70,6 +70,7 @@ TEST_F(FileTests, test_sanity) {
   row_map["attributes"] = NormalType;
   row_map["volume_serial"] = NormalType;
   row_map["file_id"] = NormalType;
+  row_map["product_version"] = NormalType;
 #endif
 
   validate_rows(data, row_map);


### PR DESCRIPTION
Here's an initial PR which adds Windows file version information to the `file` table. It adds a new column called "version", which is populated using version information from the `dwFileVersion*` fields of the `VS_FIXEDFILEINFO` [structure](https://docs.microsoft.com/en-us/windows/desktop/api/verrsrc/ns-verrsrc-tagvs_fixedfileinfo).

A few outstanding issues/questions:

- In my testing, for some reason, the file information retrieved from the API is inconsistent when compared against the information retrieved using Powershell.

![image](https://user-images.githubusercontent.com/2467355/51705864-c33eec80-1fea-11e9-8e29-9ec326ab1db7.png)

I am currently looking into this. A few resources suggest that it has something to do with a build manifest. (https://stackoverflow.com/a/38069323/1790085, https://blogs.msdn.microsoft.com/oldnewthing/20120315-00/?p=8093)

- The current implementation modifies the `file` table by introducing a new column that is only meaningful for Windows. To me it seems like upstream might have some reservations with this. Is this a legitimate concern? I suppose other options would include making a separate table just for file version information, or potentially implementing this in an extension.

- The structure also contains `dwProductVersion*` fields. Should those be included also?

edit: I've changed the implementation to reuse an existing function, which makes this PR pretty trivial, however it uses the Product Version instead of the File Version. Currently confirming if this is acceptable, and if it is, I think we should be able to submit this and hopefully quickly get it merged.